### PR TITLE
Added 'wheel' to requirements.txt and improved keys.py.

### DIFF
--- a/keys.py
+++ b/keys.py
@@ -8,6 +8,7 @@ from github.NamedUser import NamedUser
 NamedUser.__hash__ = lambda self: hash(self.id)
 
 import os
+import sys
 from pathlib import Path
 from configparser import ConfigParser
 
@@ -15,13 +16,13 @@ from github import Github
 
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
 if not GITHUB_TOKEN:
-    print("GITHUB_TOKEN environment variable unset")
-    exit(1)
+    print("GITHUB_TOKEN environment variable is not set.")
+    sys.exit(1)
 
 KEYS_CONFIG = Path(os.environ.get("KEYS_CONFIG", "keys.ini"))
 if not KEYS_CONFIG.exists():
-    print('Config file "{}" does not exist. Specify one in KEYS_CONFIG environment variable.')
-    exit(1)
+    print('Config file "{}" does not exist. Specify one in KEYS_CONFIG environment variable.'.format(KEYS_CONFIG))
+    sys.exit(1)
 
 
 github = Github(GITHUB_TOKEN)
@@ -29,7 +30,7 @@ github.get_rate_limit()
 print("You have used {} requests of {}".format(*github.rate_limiting))
 
 config = ConfigParser()
-config.read(KEYS_CONFIG)
+config.read(str(KEYS_CONFIG))
 
 
 def get_org_members(org, teams=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+wheel==0.30.0
 PyGithub==1.35
 PyJWT==1.5.3


### PR DESCRIPTION
Changes made in keys.py:
* Changed exit --> sys.exit because the former is intended for interactive shell only.
* Added a missing format call in an error message outputting.
* Made config.read work in Python versions earlier than 3.6. Before Python 3.6, it is necessary to convert the argument passed to config.read into a string.